### PR TITLE
Fix package name in __init__.py

### DIFF
--- a/src/randname/__init__.py
+++ b/src/randname/__init__.py
@@ -17,7 +17,7 @@ from randname.core import (
     show_data,
 )
 
-__title__ = "randname"
+__title__ = "rname"
 __version__ = version(__title__)
 __author__ = "Adam Walkiewicz"
 __license__ = "MIT"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct __title__ from "randname" to "rname" in __init__.py